### PR TITLE
Fixes for initial and final versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ pkg/*
 *.gem
 .bundle
 coverage
+.rvmrc
+.idea

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,8 +41,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activerecord (>= 3.0.0)
-  activesupport (>= 3.0.0)
   rcov
   rspec
   simplecov

--- a/lib/vestal_versions/creation.rb
+++ b/lib/vestal_versions/creation.rb
@@ -36,7 +36,7 @@ module VestalVersions
 
         # Creates an initial version upon creation of the parent record.
         def create_initial_version
-          versions.create(version_attributes.merge(:number => 1))
+          versions.create(version_attributes.merge(:number => 1, :modifications => attributes))
           reset_version_changes
           reset_version
         end

--- a/lib/vestal_versions/deletion.rb
+++ b/lib/vestal_versions/deletion.rb
@@ -31,7 +31,7 @@ module VestalVersions
         end
 
         def create_destroyed_version
-          create_version({:modifications => attributes, :number => last_version + 1, :tag => 'deleted'})
+          create_version(version_attributes.merge(:modifications => attributes, :tag => 'deleted'))
         end
 
     end

--- a/spec/vestal_versions/creation_spec.rb
+++ b/spec/vestal_versions/creation_spec.rb
@@ -85,6 +85,11 @@ describe VestalVersions::Creation do
       User.prepare_versioned_options(:initial_version => true)
       subject.versions.first.number.should == 1
     end
+    
+    it "stores a snapshot of the model attributes as modifications" do
+      User.prepare_versioned_options(:initial_version => true)
+      subject.versions.first.modifications.should == User.last.attributes
+    end  
   end
 
 end

--- a/spec/vestal_versions/deletion_spec.rb
+++ b/spec/vestal_versions/deletion_spec.rb
@@ -25,6 +25,13 @@ describe VestalVersions::Deletion do
       VestalVersions::Version.last.tag.should == 'deleted'
     end
 
+    it "creates a version with user" do
+      user = User.create(:first_name => "Naruto", :last_name => "Uzumaki")
+      subject.updated_by = user
+
+      subject.destroy
+      VestalVersions::Version.last.user.should == user
+    end
   end
 
   context "deleted versions" do


### PR DESCRIPTION
### Snapshot of model attributes in modifications (instead of hash) for initial versions

Currently, when initial_version is set to true, the initial version is created with an empty hash in modifications. 

However, I propose storing a snapshot of the model attributes in modifications for easy review, as in cases where the versioned object is deleted, you will still have a history of how the object was like in its initial state.

Note that as the versioned object is deleted, revert_to method cannot be used to obtain the initial state of the versioned, so a better solution, IMO, is to store a snapshot.
### Creates a version with user on destroying a versioned object, if updated_by was set

When the option :dependent => :tracking is used, and a versioned object is deleted, a version would be created to record the deletion of the object along with its last seen attributes (so that it can be reverted).

However, it does not capture information of who deleted that versioned object, even when :updated_by was set.

Commit d66a190 fixes this problem.
