### PR TITLE
Eliminate Rails 3.1 deprecation warnings

### DIFF
--- a/lib/vestal_versions/options.rb
+++ b/lib/vestal_versions/options.rb
@@ -28,7 +28,7 @@ module VestalVersions
         #   :order => "#{options[:class_name].constantize.table_name}.#{connection.quote_column_name('number')} ASC"
         # )
 
-        class_inheritable_accessor :vestal_versions_options
+        class_attribute :vestal_versions_options
         self.vestal_versions_options = options.dup
 
         options.merge!(


### PR DESCRIPTION
Simple one: class_inheritable_accessor -> class_attribute

Thanks!
