### PR TITLE
Added a way to get each revision at once.  Very useful when displaying the history of an object.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,8 +41,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activerecord (>= 3.0.0)
-  activesupport (>= 3.0.0)
   rcov
   rspec
   simplecov

--- a/lib/vestal_versions/reversion.rb
+++ b/lib/vestal_versions/reversion.rb
@@ -46,6 +46,16 @@ module VestalVersions
         version != last_version
       end
 
+      # Returns an array of clones.  Each clone is a single version from the range provided.
+      def get_versions(range)
+        versions = []
+        range.each do |version_number|
+          revert_to(version_number)
+          versions << self.clone
+        end
+        self.reload
+        versions
+      end
       private
 
         # Mixes in the reverted_from value if it is currently within a revert

--- a/spec/vestal_versions/reversion_spec.rb
+++ b/spec/vestal_versions/reversion_spec.rb
@@ -100,4 +100,8 @@ describe VestalVersions::Reversion do
     subject.versions.last.reverted_from.should be_nil
   end
 
+  it "is able to return an array of clones of a range of revisions" do
+    versions = subject.get_versions(1..3)
+    versions.count.should == 3
+  end
 end


### PR DESCRIPTION
Added get_versions - a method that returns an array of reverted versions.  They are cloned, so each one will be a legitimate copy of that particular revision.

The current method is slow, but it works.  call get_versions (1..5) on a versioned object and it will return fully reverted clones of the object representing versions 1-5.
