### PR TITLE
Fixes for newer ActiveRecord

### DIFF
--- a/lib/vestal_versions/changes.rb
+++ b/lib/vestal_versions/changes.rb
@@ -26,7 +26,7 @@ module VestalVersions
         backward ? chain.pop : chain.shift unless from_number == 1 || to_number == 1
 
         chain.inject({}) do |changes, version|
-          changes.append_changes!(backward ? version.changes.reverse_changes : version.changes)
+          changes.append_changes!(backward ? version.changes.reverse_changes : version.changes).symbolize_keys
         end
       end
 

--- a/lib/vestal_versions/options.rb
+++ b/lib/vestal_versions/options.rb
@@ -28,7 +28,7 @@ module VestalVersions
         #   :order => "#{options[:class_name].constantize.table_name}.#{connection.quote_column_name('number')} ASC"
         # )
 
-        class_inheritable_accessor :vestal_versions_options
+        class_attribute :vestal_versions_options
         self.vestal_versions_options = options.dup
 
         options.merge!(

--- a/lib/vestal_versions/versions.rb
+++ b/lib/vestal_versions/versions.rb
@@ -15,14 +15,14 @@ module VestalVersions
       condition = (from_number == to_number) ? to_number : Range.new(*[from_number, to_number].sort)
       all(
         :conditions => {:number => condition},
-        :order => "#{aliased_table_name}.#{connection.quote_column_name('number')} #{(from_number > to_number) ? 'DESC' : 'ASC'}"
+        :order => "#{table_name}.#{connection.quote_column_name('number')} #{(from_number > to_number) ? 'DESC' : 'ASC'}"
       )
     end
 
     # Returns all version records created before the version associated with the given value.
     def before(value)
       return [] if (number = number_at(value)).nil?
-      all(:conditions => "#{aliased_table_name}.#{connection.quote_column_name('number')} < #{number}")
+      all(:conditions => "#{table_name}.#{connection.quote_column_name('number')} < #{number}")
     end
 
     # Returns all version records created after the version associated with the given value.
@@ -30,7 +30,7 @@ module VestalVersions
     # This is useful for dissociating records during use of the +reset_to!+ method.
     def after(value)
       return [] if (number = number_at(value)).nil?
-      all(:conditions => "#{aliased_table_name}.#{connection.quote_column_name('number')} > #{number}")
+      all(:conditions => "#{table_name}.#{connection.quote_column_name('number')} > #{number}")
     end
 
     # Returns a single version associated with the given value. The following formats are valid:
@@ -49,7 +49,7 @@ module VestalVersions
     #   untouched.
     def at(value)
       case value
-        when Date, Time then last(:conditions => ["#{aliased_table_name}.created_at <= ?", value.to_time])
+        when Date, Time then last(:conditions => ["#{table_name}.created_at <= ?", value.to_time])
         when Numeric then find_by_number(value.floor)
         when String then find_by_tag(value)
         when Symbol then respond_to?(value) ? send(value) : nil


### PR DESCRIPTION
Hi, there are a few problems with Vestal Versions when used with the newest ActiveRecord - here are some fixes. 

I've also (more controversially) symbolized keys coming out of the Changes#changes_between method, that might screw things up - I can revert this if you like. 

I'm just about to release a simple gem for doing diffs on Vestal Versions (using another gem called Diffy). For the moment I guess I'll just depend on my fork, but it'd be nice to get back to the mainline if possible. 
