### PR TITLE
Don't use conflicting module names - messes up 'included' blocks, etc

### DIFF
--- a/lib/vestal_versions/users.rb
+++ b/lib/vestal_versions/users.rb
@@ -6,7 +6,7 @@ module VestalVersions
 
     included do
       attr_accessor :updated_by
-      Version.class_eval{ include VersionMethods }
+      Version.class_eval{ include UsersMethods }
     end
 
     # Methods added to versioned ActiveRecord::Base instances to enable versioning with additional
@@ -22,7 +22,7 @@ module VestalVersions
   end
 
   # Instance methods added to VestalVersions::Version to accomodate incoming user information.
-  module VersionMethods
+  module UsersMethods
     extend ActiveSupport::Concern
 
     included do

--- a/lib/vestal_versions/version_tagging.rb
+++ b/lib/vestal_versions/version_tagging.rb
@@ -4,6 +4,10 @@ module VestalVersions
   module VersionTagging
     extend ActiveSupport::Concern
 
+    included do
+      Version.class_eval{ include VersionTaggingMethods }
+    end
+
     # Adds an instance method which allows version tagging through the parent object.
 
     # Accepts a single string argument which is attached to the version record associated with
@@ -21,7 +25,7 @@ module VestalVersions
   end
 
   # Instance methods included into VestalVersions::Version to enable version tagging.
-  module VersionMethods
+  module VersionTaggingMethods
     extend ActiveSupport::Concern
 
     included do
@@ -43,7 +47,5 @@ module VestalVersions
     def validate_tags?
       tagged? && tag != 'deleted'
     end
-
-    Version.class_eval{ include VersionMethods }
   end
 end


### PR DESCRIPTION
This isn't evident with ClassMethods, but only because ActiveRecord::Concern does some magic...
