### PR TITLE
partial rails 4.x support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,7 @@ gemfile:
   - gemfiles/activerecord_3_2.gemfile
   - gemfiles/activerecord_4_0.gemfile
 script: rspec
+matrix:
+   exclude:
+      - rvm: 1.9.2
+        gemfile: gemfiles/activerecord_4_0.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,5 @@ gemfile:
   - gemfiles/activerecord_3_0.gemfile
   - gemfiles/activerecord_3_1.gemfile
   - gemfiles/activerecord_3_2.gemfile
+  - gemfiles/activerecord_4_0.gemfile
 script: rspec

--- a/gemfiles/activerecord_4_0.gemfile
+++ b/gemfiles/activerecord_4_0.gemfile
@@ -1,0 +1,9 @@
+source 'https://rubygems.org'
+
+gem 'activerecord', '~> 4.0'
+
+gemspec :path => '../'
+
+gem 'rake', '>= 0.9'
+gem 'rspec', '~> 2.0'
+gem 'sqlite3', '~> 1.0'

--- a/vestal_versions.gemspec
+++ b/vestal_versions.gemspec
@@ -10,8 +10,8 @@ Gem::Specification.new do |gem|
   gem.summary     = gem.description
   gem.homepage    = 'http://github.com/laserlemon/vestal_versions'
 
-  gem.add_dependency 'activerecord', '~> 3.0'
-  gem.add_dependency 'activesupport', '~> 3.0'
+  gem.add_dependency 'activerecord', '>= 3.0', '< 5'
+  gem.add_dependency 'activesupport', '>= 3.0', '< 5'
 
   gem.files         = `git ls-files`.split($\)
   gem.test_files    = gem.files.grep(/^spec/)


### PR DESCRIPTION
At the minimum to support Rails 4.x we'll need to loosen the dependency on ActiveRecord and ActiveSupport (I also noticed a number of deprecations but we can deal with that later).  This PR will allow AR and AS verisons 3.x and 4.x.

If you'd like I can change it to only support '<= 4.0' but we'll be right back to this point once Rails 4.1 lands
