### PR TITLE
Add new RVM dotfiles to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ test/tmp
 test/version_tmp
 tmp
 _yardoc
+.ruby-version
+.ruby-gemset


### PR DESCRIPTION
I noticed that the .gitignore doesn't include the newer standardized dotfiles for RVM, rbenv, etc.

Added them here
