### PR TITLE
FIX ordering with Versions#at with Time

### DIFF
--- a/lib/vestal_versions/versions.rb
+++ b/lib/vestal_versions/versions.rb
@@ -64,7 +64,7 @@ module VestalVersions
     #   untouched.
     def at(value)
       case value
-        when Date, Time then where("#{table_name}.created_at <= ?", value.to_time).last
+        when Date, Time then where("#{table_name}.created_at <= ?", value.to_time).order(:created_at).last
         when Numeric then find_by_number(value.floor)
         when String then find_by_tag(value)
         when Symbol then respond_to?(value) ? send(value) : nil


### PR DESCRIPTION
When querying `#at(value)` with a time value, the result returned is the
`last` one, with no condition on ordering. Though it is the default
ordering with `id` that is used. While this is fine with incremental id,
this will fail with other types like uuids.
Fix it by explicitly telling the order clause to use the field
`created_at`
