### PR TITLE
Split versioned models and Version concerns into separate files

### DIFF
--- a/lib/vestal_versions.rb
+++ b/lib/vestal_versions.rb
@@ -47,6 +47,8 @@ module VestalVersions
   autoload :VersionTagging
   autoload :Versioned
   autoload :Versions
+  autoload :VersionUsers
+  autoload :VersionVersionTagging
 
   class << self
     delegate :config, :configure, :to => Version

--- a/lib/vestal_versions/users.rb
+++ b/lib/vestal_versions/users.rb
@@ -6,7 +6,6 @@ module VestalVersions
 
     included do
       attr_accessor :updated_by
-      Version.class_eval{ include VersionMethods }
     end
 
     # Methods added to versioned ActiveRecord::Base instances to enable versioning with additional
@@ -19,36 +18,5 @@ module VestalVersions
     def version_attributes
       super.merge(:user => updated_by)
     end
-  end
-
-  # Instance methods added to VestalVersions::Version to accomodate incoming user information.
-  module VersionMethods
-    extend ActiveSupport::Concern
-
-    included do
-      belongs_to :user, :polymorphic => true
-
-      alias_method_chain :user, :name
-      alias_method_chain :user=, :name
-    end
-
-    # Overrides the +user+ method created by the polymorphic +belongs_to+ user association. If
-    # the association is absent, defaults to the +user_name+ string column. This allows
-    # VestalVersions::Version#user to either return an ActiveRecord::Base object or a string,
-    # depending on what is sent to the +user_with_name=+ method.
-    def user_with_name
-      user_without_name || user_name
-    end
-
-    # Overrides the +user=+ method created by the polymorphic +belongs_to+ user association.
-    # Based on the class of the object given, either the +user+ association columns or the
-    # +user_name+ string column is populated.
-    def user_with_name=(value)
-      case value
-        when ActiveRecord::Base then self.user_without_name = value
-        else self.user_name = value
-      end
-    end
-
   end
 end

--- a/lib/vestal_versions/version.rb
+++ b/lib/vestal_versions/version.rb
@@ -6,6 +6,8 @@ module VestalVersions
   class Version < ActiveRecord::Base
     include Comparable
     include ActiveSupport::Configurable
+    include VersionUsers
+    include VersionVersionTagging
 
     # Associate polymorphically with the parent record.
     belongs_to :versioned, :polymorphic => true

--- a/lib/vestal_versions/version_tagging.rb
+++ b/lib/vestal_versions/version_tagging.rb
@@ -21,31 +21,4 @@ module VestalVersions
       t
     end
   end
-
-  # Instance methods included into VestalVersions::Version to enable version tagging.
-  module VersionMethods
-    extend ActiveSupport::Concern
-
-    included do
-      validates_uniqueness_of :tag, :scope => [:versioned_id, :versioned_type], :if => :validate_tags?
-    end
-
-    # Attaches the given string to the version tag column. If the uniqueness validation fails,
-    # nil is returned. Otherwise, the given string is returned.
-    def tag!(tag)
-      write_attribute(:tag, tag)
-      save ? tag : nil
-    end
-
-    # Simply returns a boolean signifying whether the version instance has a tag value attached.
-    def tagged?
-      !tag.nil?
-    end
-
-    def validate_tags?
-      tagged? && tag != 'deleted'
-    end
-
-    Version.class_eval{ include VersionMethods }
-  end
 end

--- a/lib/vestal_versions/version_users.rb
+++ b/lib/vestal_versions/version_users.rb
@@ -1,0 +1,32 @@
+module VestalVersions
+  # Instance methods added to VestalVersions::Version to accomodate incoming user information.
+  module VersionUsers
+    extend ActiveSupport::Concern
+
+    included do
+      belongs_to :user, :polymorphic => true
+
+      alias_method_chain :user, :name
+      alias_method_chain :user=, :name
+    end
+
+    # Overrides the +user+ method created by the polymorphic +belongs_to+ user association. If
+    # the association is absent, defaults to the +user_name+ string column. This allows
+    # VestalVersions::Version#user to either return an ActiveRecord::Base object or a string,
+    # depending on what is sent to the +user_with_name=+ method.
+    def user_with_name
+      user_without_name || user_name
+    end
+
+    # Overrides the +user=+ method created by the polymorphic +belongs_to+ user association.
+    # Based on the class of the object given, either the +user+ association columns or the
+    # +user_name+ string column is populated.
+    def user_with_name=(value)
+      case value
+        when ActiveRecord::Base then self.user_without_name = value
+        else self.user_name = value
+      end
+    end
+
+  end
+end

--- a/lib/vestal_versions/version_version_tagging.rb
+++ b/lib/vestal_versions/version_version_tagging.rb
@@ -1,0 +1,26 @@
+module VestalVersions
+  # Instance methods included into VestalVersions::Version to enable version tagging.
+  module VersionVersionTagging
+    extend ActiveSupport::Concern
+
+    included do
+      validates_uniqueness_of :tag, :scope => [:versioned_id, :versioned_type], :if => :validate_tags?
+    end
+
+    # Attaches the given string to the version tag column. If the uniqueness validation fails,
+    # nil is returned. Otherwise, the given string is returned.
+    def tag!(tag)
+      write_attribute(:tag, tag)
+      save ? tag : nil
+    end
+
+    # Simply returns a boolean signifying whether the version instance has a tag value attached.
+    def tagged?
+      !tag.nil?
+    end
+
+    def validate_tags?
+      tagged? && tag != 'deleted'
+    end
+  end
+end

--- a/vestal_versions.gemspec
+++ b/vestal_versions.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |gem|
   gem.name    = 'vestal_versions'
-  gem.version = '2.0.0'
+  gem.version = '2.0.1'
 
   gem.authors     = ['Steve Richert', "James O'Kelly", 'C. Jason Harrelson']
   gem.email       = ['steve.richert@gmail.com', 'dreamr.okelly@gmail.com', 'jason@lookforwardenterprises.com']
@@ -11,8 +11,8 @@ Gem::Specification.new do |gem|
   gem.homepage    = 'http://github.com/laserlemon/vestal_versions'
   gem.license     = 'MIT'
 
-  gem.add_dependency 'activerecord', '>= 3', '< 5'
-  gem.add_dependency 'activesupport', '>= 3', '< 5'
+  gem.add_dependency 'activerecord', '>= 4.1.0.rc1', '< 5'
+  gem.add_dependency 'activesupport', '>= 4.1.0.rc1', '< 5'
 
   gem.add_development_dependency 'bundler', '~> 1.0'
   gem.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
With Rails 4.1.0rc1, vestal_versions fails to load because of "Cannot define multiple 'included' blocks for a Concern vestal_versions".

I can see why the tagging and user modules (for the versioned model and the Version class) are in the same files. Unfortunately, the latest ActiveSupport::Concern doesn't allow this organization.

This PR's changes allow vestal_versions to work with Rails 4.1.0.rc1 and the tests pass, but they are illustrative, not a good solution. I think options include: 
- Submit a PR to Rails changing how ActiveSupport works
- Organize code by tagging and users. So we'd have tagging/versioned, tagging/version, users/versioned, users/version
- Organize code by versioned and version. So we'd have versioned/tagging, versioned/users, versions/tagging, versions/users

I'm happy to implement any of these or another, better idea.
