### PR TITLE
Fix for migration file extension

### DIFF
--- a/lib/generators/vestal_versions/migration/migration_generator.rb
+++ b/lib/generators/vestal_versions/migration/migration_generator.rb
@@ -9,7 +9,7 @@ module VestalVersions
       argument :name, :type => :string, :default => 'create_vestal_versions'
 
       def generate_files
-        migration_template 'migration.rb', "db/migrate/#{name}"
+        migration_template 'migration.rb', "db/migrate/#{name}.rb"
         template 'initializer.rb', 'config/initializers/vestal_versions.rb'
       end
     end

--- a/lib/vestal_versions/users.rb
+++ b/lib/vestal_versions/users.rb
@@ -6,7 +6,7 @@ module VestalVersions
 
     included do
       attr_accessor :updated_by
-      Version.class_eval{ include VersionMethods }
+      Version.class_eval{ include UserVersionMethods }
     end
 
     # Methods added to versioned ActiveRecord::Base instances to enable versioning with additional
@@ -22,7 +22,7 @@ module VestalVersions
   end
 
   # Instance methods added to VestalVersions::Version to accomodate incoming user information.
-  module VersionMethods
+  module UserVersionMethods
     extend ActiveSupport::Concern
 
     included do

--- a/lib/vestal_versions/version_tagging.rb
+++ b/lib/vestal_versions/version_tagging.rb
@@ -23,7 +23,7 @@ module VestalVersions
   end
 
   # Instance methods included into VestalVersions::Version to enable version tagging.
-  module VersionMethods
+  module TaggingVersionMethods
     extend ActiveSupport::Concern
 
     included do
@@ -46,6 +46,6 @@ module VestalVersions
       tagged? && tag != 'deleted'
     end
 
-    Version.class_eval{ include VersionMethods }
+    Version.class_eval{ include TaggingVersionMethods }
   end
 end


### PR DESCRIPTION
Fixed missing `.rb` extension here - https://github.com/laserlemon/vestal_versions/blob/master/lib/generators/vestal_versions/migration/migration_generator.rb#L12.
